### PR TITLE
Added TNK OperatorID

### DIFF
--- a/src/chargecloudapi/api.py
+++ b/src/chargecloudapi/api.py
@@ -11,6 +11,7 @@ operatorIDs = [
     OperatorID(name="SW Kiel", op_id="6336fe713f2eb7fa04b97ff6651b76f8"),
     OperatorID(name="Rheinenergie", op_id="c4ce9bb82a86766833df8a4818fa1b5c"),
     OperatorID(name="Chargemaker", op_id="830de8931b1d8dff36808d2173a57735"),
+    OperatorID(name="TNK", op_id="d018c2c8d1c8f63be6923a6282eec650"),
 ]
 
 


### PR DESCRIPTION
Tested in local Home Assistant integration - for me TankE charging points are now back to being fully visible.